### PR TITLE
Migrate to PureScript 0.12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,11 +11,9 @@
     "output"
   ],
   "dependencies": {
-    "purescript-generics": "^4.0",
-    "purescript-parsing": "^4.3",
-    "purescript-string-parsers": "^3.0",
-    "purescript-aff": "^4.0",
-    "purescript-transformers": "^3.4"
+    "purescript-string-parsers": "^4.0",
+    "purescript-aff": "^5.0",
+    "purescript-transformers": "^4.1"
   },
   "repository": {
     "type": "git",
@@ -23,6 +21,6 @@
   },
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "purescript-spec": "^2.0.0"
+    "purescript-spec": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "test": "test"
   },
   "dependencies": {
-    "bower": "^1.8.0",
-    "pulp": "^11.0.2",
-    "purescript": "^0.11.6"
+    "bower": "^1.8.4",
+    "pulp": "^12.3.0",
+    "purescript": "^0.12.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Hi Dennis! With the latest version of the PureScript compiler, this library needs a few updates to be compatible with the rest of the ecosystem on `0.12`. This pull request updates the library to be compatible and verifies that the tests run successfully.

I left functionality almost unchanged, but there were a few places I had to update. You might want to double-check these to ensure you're comfortable with the changes.

1. I removed the `purescript-parsing` dependency because it doesn't appear to be used; only `purescript-string-parsing`. This trims things down a little. Installation and building from scratch still works fine.
2. I removed `purescript-generics` because it's deprecated and will no longer be updated. The supported version of generics is `purescript-generics-rep`, and I updated the library to use that instead.
3. `fromCharCode` no longer returns a `Char` -- now, it's just a synonym for `fromEnum` which returns a `Maybe Char`. Since you're using chars that definitely exist, I opted to make a helper function called `unsafeFromCharCode` that can be used in these places. However, if you are uncomfortable with this, perhaps I could thread a `Maybe` through the parsers.
4. I removed all effect rows and replaced `Eff` with `Effect` as per the `0.12` changes. Functionally equivalent.

So long as you're comfortable with these changes, this should be good to go:

```sh
pulp version
-> 3.0.0
pulp publish
```