### PR TITLE
Added generics-rep to dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "purescript-string-parsers": "^4.0",
     "purescript-aff": "^5.0",
-    "purescript-transformers": "^4.1"
+    "purescript-transformers": "^4.1",
+    "purescript-generics-rep": "^6.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When installed without devDependencies, we can't compile it, because `generics-rep` is not included in dependencies.
I added it :)