### PR TITLE
Update for string-parsers v7.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.pulp-cache/
 /pursuit.json
 /src/.webpack.js
+/.psc-ide-port

--- a/bower.json
+++ b/bower.json
@@ -1,17 +1,10 @@
 {
   "name": "purescript-email-validate",
   "version": "1.0.8",
-  "moduleType": [
-    "node"
-  ],
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "output"
-  ],
+  "moduleType": ["node"],
+  "ignore": ["**/.*", "node_modules", "bower_components", "output"],
   "dependencies": {
-    "purescript-string-parsers": "^6.0.0",
+    "purescript-string-parsers": "^7.0.0",
     "purescript-aff": "^6.0.0",
     "purescript-transformers": "^5.0.0"
   },

--- a/src/Text/Email/Parser.purs
+++ b/src/Text/Email/Parser.purs
@@ -22,9 +22,7 @@ import Data.Maybe (fromJust)
 import Data.String (Pattern(..), contains)
 import Data.String.CodeUnits (singleton)
 import Partial.Unsafe (unsafePartial)
-import Text.Parsing.StringParser (Parser)
-import Text.Parsing.StringParser.Combinators (many, many1, optional, sepBy1)
-import Text.Parsing.StringParser.CodePoints (char, eof, satisfy)
+import StringParser (Parser, many, many1, optional, sepBy1, char, eof, satisfy)
 
 -- | Represents an email address.
 newtype EmailAddress = EmailAddress { localPart :: String

--- a/src/Text/Email/Validate.purs
+++ b/src/Text/Email/Validate.purs
@@ -14,7 +14,7 @@ import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Text.Email.Parser (EmailAddress(..), addrSpec, domainPart, localPart, toString)
-import Text.Parsing.StringParser (ParseError, runParser)
+import StringParser (ParseError, runParser)
 
 -- | Smart constructor for an email address
 emailAddress :: String -> Maybe EmailAddress


### PR DESCRIPTION
The `string-parsers` library has dropped the `Text.Parsing` prefix. Fixes #23 by updating our imports accordingly.